### PR TITLE
feat: email 가입 구현

### DIFF
--- a/src/main/java/org/example/cafe/domain/member/controller/MemberController.java
+++ b/src/main/java/org/example/cafe/domain/member/controller/MemberController.java
@@ -1,0 +1,26 @@
+package org.example.cafe.domain.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.cafe.domain.member.entity.Member;
+import org.example.cafe.domain.member.service.MemberService;
+import org.example.cafe.global.rsData.RsData;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<RsData<Member>> registerOrFindMember(@RequestBody Member requestMember) {
+        Member member = memberService.registerOrFindMember(requestMember);
+        return ResponseEntity.ok(new RsData<>("200", "회원 조회/등록 완료", member));
+    }
+
+}

--- a/src/main/java/org/example/cafe/domain/member/entity/Member.java
+++ b/src/main/java/org/example/cafe/domain/member/entity/Member.java
@@ -1,0 +1,35 @@
+package org.example.cafe.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "Member")
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email", length = 50, nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "address", length = 50, nullable = false)
+    private String address;
+
+    @Column(name = "postalCode", length = 50, nullable = false)
+    private String postalCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", length = 20, nullable = false)
+    private Role role;
+
+}

--- a/src/main/java/org/example/cafe/domain/member/entity/Role.java
+++ b/src/main/java/org/example/cafe/domain/member/entity/Role.java
@@ -1,0 +1,5 @@
+package org.example.cafe.domain.member.entity;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/org/example/cafe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/example/cafe/domain/member/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package org.example.cafe.domain.member.repository;
+
+import org.example.cafe.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/org/example/cafe/domain/member/service/MemberService.java
+++ b/src/main/java/org/example/cafe/domain/member/service/MemberService.java
@@ -1,0 +1,28 @@
+package org.example.cafe.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.cafe.domain.member.entity.Member;
+import org.example.cafe.domain.member.entity.Role;
+import org.example.cafe.domain.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * 이메일 입력 시
+     * 기존 회원일 경우: 기존 member return
+     * 회원이 아닐 경우: memberRepository 에 save
+     */
+
+    public Member registerOrFindMember(Member member) {
+        return memberRepository.findByEmail(member.getEmail())
+                .orElseGet(() -> {
+                        member.setRole(Role.USER); //기본값 user
+                        return memberRepository.save(member);
+                });
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
#9 

## 📌 이메일 가입 구현
- 이메일 기준 회원 분류
기존 등록된 이메일이면 member 반환, 
아닐 시 레포지토리에 저장

## 👩‍💻 
enum으로 회원 user, admin 분리

## ✅  확인 사항
- role 기본값은 user입니다
- rule -> 이름 role로 변환 

